### PR TITLE
fix: scroll focused last item into view

### DIFF
--- a/src/parts/ListFocusIndexScrollDown/ListFocusIndexScrollDown.ts
+++ b/src/parts/ListFocusIndexScrollDown/ListFocusIndexScrollDown.ts
@@ -10,16 +10,16 @@ export const focusIndexScrollDown = <T, State extends List<T>>(
   itemsLength: number,
 ): State => {
   const { finalDeltaY, headerHeight, height, scrollBarHeight } = state
-  const newMaxLineY = Math.min(index + 1, itemsLength)
   const fittingItems = GetNumberOfVisibleItems.getNumberOfVisibleItems(
     listHeight,
     itemHeight,
   )
-  const newMinLineY = Math.max(newMaxLineY - fittingItems, 0)
-  const newDeltaY =
-    itemsLength < fittingItems
-      ? 0
-      : newMinLineY * itemHeight - (listHeight % itemHeight) + itemHeight
+  const newDeltaY = Math.min(
+    Math.max((index + 1) * itemHeight - listHeight, 0),
+    finalDeltaY,
+  )
+  const newMinLineY = Math.floor(newDeltaY / itemHeight)
+  const newMaxLineY = Math.min(newMinLineY + fittingItems, itemsLength)
   const scrollBarY = getScrollBarY(
     newDeltaY,
     finalDeltaY,

--- a/test/ListFocusNext.test.ts
+++ b/test/ListFocusNext.test.ts
@@ -18,3 +18,26 @@ test('focusNext updates focusedIndex to the next index', () => {
   const result = ListFocusNext.focusNext(initialState)
   expect(result.focusedIndex).toBe(1)
 })
+
+test('focusNext scrolls the last item into view', () => {
+  const items = Array.from({ length: 10 }, (_, index) => `item${index + 1}`)
+  const initialState: List<string> = {
+    ...createDefaultState(),
+    finalDeltaY: 340,
+    focusedIndex: 8,
+    headerHeight: 41,
+    height: 421,
+    itemHeight: 72,
+    items,
+    maxLineY: 10,
+    minLineY: 3,
+    scrollBarHeight: 200,
+  }
+
+  const result = ListFocusNext.focusNext(initialState)
+
+  expect(result.focusedIndex).toBe(9)
+  expect(result.deltaY).toBe(340)
+  expect(result.minLineY).toBe(4)
+  expect(result.maxLineY).toBe(10)
+})


### PR DESCRIPTION
Fix keyboard navigation at the bottom of virtualized lists so advancing from the penultimate item renders and focuses the final item.